### PR TITLE
Fix unique names

### DIFF
--- a/instance-profile.tf
+++ b/instance-profile.tf
@@ -37,32 +37,32 @@ data "aws_iam_policy_document" "vault_client" {
 
 // aws_iam_role
 resource "aws_iam_role" "control_plane" {
-  name               = "control-plane-${random_pet.env.id}"
+  name               = "${var.prefix}-control-plane-${random_pet.env.id}"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 resource "aws_iam_role" "worker_plane" {
-  name               = "worker-plane-${random_pet.env.id}"
+  name               = "${var.prefix}-worker-plane-${random_pet.env.id}"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 // aws_iam_instance_profile
 resource "aws_iam_instance_profile" "control_plane" {
-  name = "control-plane-${random_pet.env.id}"
+  name = "${var.prefix}-control-plane-${random_pet.env.id}"
   role = aws_iam_role.control_plane.name
 }
 resource "aws_iam_instance_profile" "worker_plane" {
-  name = "worker-plane-${random_pet.env.id}"
+  name = "${var.prefix}-worker-plane-${random_pet.env.id}"
   role = aws_iam_role.worker_plane.name
 }
 
 // aws_iam_role_policy
 resource "aws_iam_role_policy" "vault_kms_unseal" {
-  name   = "vault-kms-unseal-${random_pet.env.id}"
+  name   = "${var.prefix}-vault-kms-unseal-${random_pet.env.id}"
   role   = aws_iam_role.control_plane.id
   policy = data.aws_iam_policy_document.vault_kms_unseal.json
 }
 resource "aws_iam_role_policy" "vault_aws_auth" {
-  name = "control-plane-policy"
+  name = "${var.prefix}-control-plane-policy"
   role = aws_iam_role.control_plane.name
 
   policy = <<-EOF
@@ -98,13 +98,13 @@ resource "aws_iam_role_policy" "vault_aws_auth" {
 }
 
 resource "aws_iam_role_policy" "vault_client" {
-  name   = "vault-client-${random_pet.env.id}"
+  name   = "${var.prefix}-vault-client-${random_pet.env.id}"
   role   = aws_iam_role.worker_plane.name
   policy = data.aws_iam_policy_document.vault_client.json
 }
 
 resource "aws_iam_role_policy" "csi" {
-  name   = "ebs-csi-client"
+  name   = "${var.prefix}-ebs-csi-client"
   role   = aws_iam_role.worker_plane.id
   policy = <<-EOF
 {

--- a/network.tf
+++ b/network.tf
@@ -24,7 +24,7 @@ module "vpc" {
 }
 
 resource "aws_lb" "hashicorp_alb" {
-  name                       = "hashicorp-alb"
+  name                       = "${var.prefix}-hashicorp-alb"
   internal                   = false #tfsec:ignore:AWS005
   load_balancer_type         = "application"
   security_groups            = [aws_security_group.alb.id]
@@ -84,7 +84,7 @@ resource "aws_lb_listener" "https_443" {
 
 // aws_lb_target_group
 resource "aws_lb_target_group" "vault" {
-  name     = "hashicorp-target-group-vault"
+  name     = "${var.prefix}-hashicorp-target-group-vault"
   port     = 8200
   protocol = "HTTP"
   vpc_id   = module.vpc.vpc_id
@@ -100,7 +100,7 @@ resource "aws_lb_target_group" "vault" {
   }
 }
 resource "aws_lb_target_group" "consul" {
-  name     = "hashicorp-target-group-consul"
+  name     = "${var.prefix}-hashicorp-target-group-consul"
   port     = 8500
   protocol = "HTTP"
   vpc_id   = module.vpc.vpc_id
@@ -116,7 +116,7 @@ resource "aws_lb_target_group" "consul" {
   }
 }
 resource "aws_lb_target_group" "nomad" {
-  name     = "hashicorp-target-group-nomad"
+  name     = "${var.prefix}-hashicorp-target-group-nomad"
   port     = 4646
   protocol = "HTTP"
   vpc_id   = module.vpc.vpc_id
@@ -132,7 +132,7 @@ resource "aws_lb_target_group" "nomad" {
   }
 }
 resource "aws_lb_target_group" "ingress" {
-  name     = "hashicorp-target-group-ingress"
+  name     = "${var.prefix}-hashicorp-target-group-ingress"
   port     = 8080
   protocol = "HTTP"
   vpc_id   = module.vpc.vpc_id

--- a/security.tf
+++ b/security.tf
@@ -1,6 +1,6 @@
 
 resource "aws_security_group" "allow_cluster_basics" {
-  name        = join("_", [var.prefix, "hashicorp_cluster_ssh_in"])
+  name        = "${var.prefix}_hashicorp_cluster_ssh_in"
   description = "Allow Hashicorp Cluster Traffic"
   vpc_id      = module.vpc.vpc_id
 
@@ -28,13 +28,13 @@ resource "aws_security_group" "allow_cluster_basics" {
   }
 
   tags = {
-    Name    = join("_", [var.prefix, "hashicorp_cluster_ssh_in"])
+    Name    = "${var.prefix}_hashicorp_cluster_ssh_in"
     Project = var.prefix
   }
 }
 
 resource "aws_security_group" "alb" {
-  name        = join("_", [var.prefix, "hashicorp_internal_alb_in"])
+  name        = "${var.prefix}_hashicorp_internal_alb_in"
   description = "Allow Hashicorp ALB Internal Traffic"
   vpc_id      = module.vpc.vpc_id
 
@@ -80,7 +80,7 @@ resource "aws_security_group" "alb" {
 }
 
 resource "aws_security_group" "internal_vault" {
-  name        = join("_", [var.prefix, "hashicorp_internal_vault_in"])
+  name        = "${var.prefix}_hashicorp_internal_vault_in"
   description = "Allow Hashicorp Vault Internal Traffic"
   vpc_id      = module.vpc.vpc_id
 
@@ -99,14 +99,14 @@ resource "aws_security_group" "internal_vault" {
   }
 
   tags = {
-    Name      = join("_", [var.prefix, "hashicorp_cluster_in"])
+    Name      = "${var.prefix}_hashicorp_cluster_in"
     Project   = var.prefix
     Component = "vault"
   }
 
 }
 resource "aws_security_group" "internal_consul" {
-  name        = join("_", [var.prefix, "hashicorp_internal_consul_in"])
+  name        = "${var.prefix}_hashicorp_internal_consul_in"
   description = "Allow Hashicorp Consul Internal Traffic"
   vpc_id      = module.vpc.vpc_id
 
@@ -151,14 +151,14 @@ resource "aws_security_group" "internal_consul" {
   }
 
   tags = {
-    Name      = join("_", [var.prefix, "hashicorp_cluster_in"])
+    Name      = "${var.prefix}_hashicorp_cluster_in"
     Project   = var.prefix
     Component = "consul"
   }
 
 }
 resource "aws_security_group" "internal_nomad" {
-  name        = join("_", [var.prefix, "hashicorp_internal_nomad_in"])
+  name        = "${var.prefix}_hashicorp_internal_nomad_in"
   description = "Allow Hashicorp Nomad Internal Traffic"
   vpc_id      = module.vpc.vpc_id
 
@@ -182,7 +182,7 @@ resource "aws_security_group" "internal_nomad" {
   }
 
   tags = {
-    Name      = join("_", [var.prefix, "hashicorp_cluster_in"])
+    Name      = "${var.prefix}_hashicorp_cluster_in"
     Project   = var.prefix
     Component = "nomad"
   }
@@ -190,7 +190,7 @@ resource "aws_security_group" "internal_nomad" {
 }
 
 resource "aws_security_group" "internal_workers" {
-  name        = join("_", [var.prefix, "hashicorp_internal_workers"])
+  name        = "${var.prefix}_hashicorp_internal_workers"
   description = "Allow Hashicorp Workers Internal Traffic"
   vpc_id      = module.vpc.vpc_id
 
@@ -246,7 +246,7 @@ resource "aws_security_group" "internal_workers" {
   }
 
   tags = {
-    Name      = join("_", [var.prefix, "hashicorp_internal_workers"])
+    Name      = "${var.prefix}_hashicorp_internal_workers"
     Project   = var.prefix
     Component = "nomad"
   }


### PR DESCRIPTION
Some resources had conflicting names when deployed on the same region.
Add prefix to make them unique by project name.

Closes #19